### PR TITLE
Making PastelView more Objc compatible.

### DIFF
--- a/Example/Pastel/ViewController.swift
+++ b/Example/Pastel/ViewController.swift
@@ -23,20 +23,20 @@ class ViewController: UIViewController {
         let pastelView = PastelView(frame: view.bounds)
         
         // Custom Direction
-        pastelView.startPoint = .bottomLeft
-        pastelView.endPoint = .topRight
+        pastelView.startPastelPoint = .bottomLeft
+        pastelView.endPastelPoint = .topRight
         
         // Custom Duration
         pastelView.animationDuration = 3.0
         
         // Custom Color
-        pastelView.setColors(colors: [UIColor(red: 156/255, green: 39/255, blue: 176/255, alpha: 1.0),
-                                      UIColor(red: 255/255, green: 64/255, blue: 129/255, alpha: 1.0),
-                                      UIColor(red: 123/255, green: 31/255, blue: 162/255, alpha: 1.0),
-                                      UIColor(red: 32/255, green: 76/255, blue: 255/255, alpha: 1.0),
-                                      UIColor(red: 32/255, green: 158/255, blue: 255/255, alpha: 1.0),
-                                      UIColor(red: 90/255, green: 120/255, blue: 127/255, alpha: 1.0),
-                                      UIColor(red: 58/255, green: 255/255, blue: 217/255, alpha: 1.0)])
+        pastelView.setColors([UIColor(red: 156/255, green: 39/255, blue: 176/255, alpha: 1.0),
+                              UIColor(red: 255/255, green: 64/255, blue: 129/255, alpha: 1.0),
+                              UIColor(red: 123/255, green: 31/255, blue: 162/255, alpha: 1.0),
+                              UIColor(red: 32/255, green: 76/255, blue: 255/255, alpha: 1.0),
+                              UIColor(red: 32/255, green: 158/255, blue: 255/255, alpha: 1.0),
+                              UIColor(red: 90/255, green: 120/255, blue: 127/255, alpha: 1.0),
+                              UIColor(red: 58/255, green: 255/255, blue: 217/255, alpha: 1.0)])
         
         pastelView.startAnimation()
         view.insertSubview(pastelView, at: 0)

--- a/Pastel/Classes/PastelView.swift
+++ b/Pastel/Classes/PastelView.swift
@@ -15,7 +15,8 @@ public class PastelView: UIView {
         static let key = "ColorChange"
     }
     
-    public enum Point {
+    @objc
+    public enum PastelPoint: Int {
         case left
         case top
         case right
@@ -24,7 +25,6 @@ public class PastelView: UIView {
         case topRight
         case bottomLeft
         case bottomRight
-        case custom(position: CGPoint)
         
         var point: CGPoint {
             switch self {
@@ -36,15 +36,25 @@ public class PastelView: UIView {
             case .topRight: return CGPoint(x: 1.0, y: 0.0)
             case .bottomLeft: return CGPoint(x: 0.0, y: 1.0)
             case .bottomRight: return CGPoint(x: 1.0, y: 1.0)
-            case .custom(let point):
-                return point
             }
         }
     }
     
     // Custom Direction
-    open var startPoint: Point = .topRight
-    open var endPoint: Point = .bottomLeft
+    open var startPoint: CGPoint = PastelPoint.topRight.point
+    open var endPoint: CGPoint = PastelPoint.bottomLeft.point
+    
+    open var startPastelPoint = PastelPoint.topRight {
+        didSet {
+            startPoint = startPastelPoint.point
+        }
+    }
+    
+    open var endPastelPoint = PastelPoint.bottomLeft {
+        didSet {
+            endPoint = endPastelPoint.point
+        }
+    }
     
     // Custom Duration
     open var animationDuration: TimeInterval = 5.0
@@ -92,8 +102,8 @@ public class PastelView: UIView {
     fileprivate func setup() {
         gradient.frame = bounds
         gradient.colors = currentGradientSet()
-        gradient.startPoint = startPoint.point
-        gradient.endPoint = endPoint.point
+        gradient.startPoint = startPoint
+        gradient.endPoint = endPoint
         gradient.drawsAsynchronously = true
         
         layer.insertSublayer(gradient, at: 0)
@@ -105,12 +115,12 @@ public class PastelView: UIView {
                 colors[(currentGradient + 1) % colors.count].cgColor]
     }
     
-    public func setColors(colors: [UIColor]) {
+    public func setColors(_ colors: [UIColor]) {
         guard colors.count > 0 else { return }
         self.colors = colors
     }
     
-    public func addColor(color: UIColor) {
+    public func addcolor(_ color: UIColor) {
         self.colors.append(color)
     }
     

--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ override func viewDidLoad() {
     let pastelView = PastelView(frame: view.bounds)
 
     // Custom Direction
-    pastelView.startPoint = .bottomLeft
-    pastelView.endPoint = .topRight
+    pastelView.startPastelPoint = .bottomLeft
+    pastelView.endPastelPoint = .topRight
 
     // Custom Duration
     pastelView.animationDuration = 3.0
 
     // Custom Color
-    pastelView.setColors(colors: [UIColor(red: 156/255, green: 39/255, blue: 176/255, alpha: 1.0),
-                                  UIColor(red: 255/255, green: 64/255, blue: 129/255, alpha: 1.0),
-                                  UIColor(red: 123/255, green: 31/255, blue: 162/255, alpha: 1.0),
-                                  UIColor(red: 32/255, green: 76/255, blue: 255/255, alpha: 1.0),
-                                  UIColor(red: 32/255, green: 158/255, blue: 255/255, alpha: 1.0),
-                                  UIColor(red: 90/255, green: 120/255, blue: 127/255, alpha: 1.0),
-                                  UIColor(red: 58/255, green: 255/255, blue: 217/255, alpha: 1.0)])
+    pastelView.setColors([UIColor(red: 156/255, green: 39/255, blue: 176/255, alpha: 1.0),
+                          UIColor(red: 255/255, green: 64/255, blue: 129/255, alpha: 1.0),
+                          UIColor(red: 123/255, green: 31/255, blue: 162/255, alpha: 1.0),
+                          UIColor(red: 32/255, green: 76/255, blue: 255/255, alpha: 1.0),
+                          UIColor(red: 32/255, green: 158/255, blue: 255/255, alpha: 1.0),
+                          UIColor(red: 90/255, green: 120/255, blue: 127/255, alpha: 1.0),
+                          UIColor(red: 58/255, green: 255/255, blue: 217/255, alpha: 1.0)])
 
     pastelView.startAnimation()
     view.insertSubview(pastelView, at: 0)


### PR DESCRIPTION
Currently PastelView is not fully objc compatible because of the Point enum.  

I made several changes to make it compatible and maintain the full original functionality:

- Point enum renamed to PastelPoint and custom case with associated type removed.
- startPoint and endPoint properties are now CGPoint allowing for setting custom points without enum
- Added startPastelPoint and endPastelPoint properties to PastelView which will set the startPoint and endPoint CGPoint properties from their didSet methods.
- Changed method definition for setColors and addColor for better readability when using. *not needed for the objc support.

- Changed code in Readme to reflect changes.

With these changes, PastelView is fully usable in objc out of the box.