### PR TITLE
modify class access control (public -> open)

### DIFF
--- a/Pastel/Classes/PastelView.swift
+++ b/Pastel/Classes/PastelView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class PastelView: UIView {
+open class PastelView: UIView {
 
     private struct Animation {
         static let keyPath = "colors"
@@ -74,11 +74,11 @@ public class PastelView: UIView {
         super.init(coder: aDecoder)
     }
     
-    public override func awakeFromNib() {
+    open override func awakeFromNib() {
         super.awakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         gradient.frame = bounds
     }
@@ -125,7 +125,7 @@ public class PastelView: UIView {
         gradient.add(animation, forKey: Animation.key)
     }
     
-    public override func removeFromSuperview() {
+    open override func removeFromSuperview() {
         super.removeFromSuperview()
         gradient.removeAllAnimations()
         gradient.removeFromSuperlayer()


### PR DESCRIPTION
I changed the access control from public to open 
in order to inherit and pre-set property values ​​inside.

ex)
```swift
class CustomPastelView: PastelView {
...
   func initialize() {
// Custom Direction
    startPoint = .bottomLeft
    endPoint = .topRight

    // Custom Duration
    animationDuration = 3.0

    // Custom Color
    setColors(colors: [UIColor(red: 156/255, green: 39/255, blue: 176/255, alpha: 1.0),
                                  UIColor(red: 255/255, green: 64/255, blue: 129/255, alpha: 1.0),
                                  UIColor(red: 123/255, green: 31/255, blue: 162/255, alpha: 1.0),
                                  UIColor(red: 32/255, green: 76/255, blue: 255/255, alpha: 1.0),
                                  UIColor(red: 32/255, green: 158/255, blue: 255/255, alpha: 1.0),
                                  UIColor(red: 90/255, green: 120/255, blue: 127/255, alpha: 1.0),
                                  UIColor(red: 58/255, green: 255/255, blue: 217/255, alpha: 1.0)])
  }
}
```