### PR TITLE
Use of unresolved identifier 'kCAFillModeForwards'

### DIFF
--- a/Pastel/Classes/PastelView.swift
+++ b/Pastel/Classes/PastelView.swift
@@ -103,7 +103,7 @@ open class PastelView: UIView {
         let animation = CABasicAnimation(keyPath: Animation.keyPath)
         animation.duration = animationDuration
         animation.toValue = currentGradientSet()
-        animation.fillMode = kCAFillModeForwards
+        animation.fillMode = .forwards
         animation.isRemovedOnCompletion = false
         animation.delegate = self
         gradient.add(animation, forKey: Animation.key)


### PR DESCRIPTION
Constant has been removed in favor of a forwards property on the CAMediaTimingFillMode type.
Solution has been tested on Xcode Version 10.0 beta 2 with Swift 4.2 and a project build for iOS 12.