### PR TITLE
Add tvOS 10.0 deployment target to Podspec

### DIFF
--- a/Pastel.podspec
+++ b/Pastel.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '8.0'
+  s.tvos.deployment_target = "10.0"
 
   s.source_files = 'Pastel/Classes/**/*'
   


### PR DESCRIPTION
Pastel works on tvOS 10.0 and up without any changes other than simply adding the deployment target to the Podspec.